### PR TITLE
Expose optimizer options for SimCLR

### DIFF
--- a/experiment/__main__.py
+++ b/experiment/__main__.py
@@ -92,6 +92,8 @@ def init_ssl_type(
         "lr": args.lr,
         "temperature": args.temperature,
         "weight_decay": args.weight_decay,
+        "optimizer": args.optimizer,
+        "momentum": args.momentum,
         "max_epochs": args.max_cycles * args.n_epochs_per_cycle,
         "parserargs": args,
         "use_temperature_schedule": args.use_temperature_schedule,

--- a/experiment/models/SSLMethods/SimCLR.py
+++ b/experiment/models/SSLMethods/SimCLR.py
@@ -29,6 +29,8 @@ class SimCLR(L.LightningModule):
         lr: float,
         temperature: float,
         weight_decay: float,
+        optimizer: str = "sgd",
+        momentum: float = 0.9,
         max_epochs: int = 500,
         hidden_dim=128,
         use_temperature_schedule: bool = False,
@@ -74,19 +76,31 @@ class SimCLR(L.LightningModule):
         return temperature
 
     def configure_optimizers(self) -> tuple[list[Optimizer], list[LRScheduler]]:
-        adam_params = {
-            "lr": self.hparams.lr,
-            "betas": (0.9, 0.95),
-        }
+        opt_name = getattr(self.hparams, "optimizer", "sgd").lower()
+        momentum = getattr(self.hparams, "momentum", 0.9)
+        lr = self.hparams.lr
+        weight_decay = self.hparams.weight_decay
 
-        if torch.cuda.is_available():
-            from deepspeed.ops.adam import DeepSpeedCPUAdam
-
-            optimizer = DeepSpeedCPUAdam(
-                self.parameters(), **adam_params, adamw_mode=True
+        if opt_name == "lars":
+            optimizer = LARS(
+                self.parameters(), lr=lr, weight_decay=weight_decay, momentum=momentum
             )
+        elif opt_name == "cpuadam":
+            adam_params = {"lr": lr, "betas": (0.9, 0.95)}
+            if torch.cuda.is_available():
+                from deepspeed.ops.adam import DeepSpeedCPUAdam
+
+                optimizer = DeepSpeedCPUAdam(
+                    self.parameters(), **adam_params, adamw_mode=True
+                )
+            else:
+                optimizer = AdamW(
+                    self.parameters(), **adam_params, weight_decay=weight_decay
+                )
         else:
-            optimizer = SGD(self.parameters(), lr=0.5, weight_decay=1e-4, momentum=0.9)
+            optimizer = SGD(
+                self.parameters(), lr=lr, weight_decay=weight_decay, momentum=momentum
+            )
 
         # Define the number of warmup epochs
         warmup_epochs = 10

--- a/experiment/utils/get_training_args.py
+++ b/experiment/utils/get_training_args.py
@@ -81,8 +81,21 @@ def get_training_args(get_defaults: bool = False) -> dict:
     parser.add_argument(
         "--weight-decay",
         type=float,
-        default=1e-6,
+        default=1e-4,
         help="Weight decay",
+    )
+    parser.add_argument(
+        "--optimizer",
+        type=str,
+        choices=["sgd", "lars", "cpuadam"],
+        default="sgd",
+        help="Optimizer to use (sgd, lars, or deepspeedcpuadam)",
+    )
+    parser.add_argument(
+        "--momentum",
+        type=float,
+        default=0.9,
+        help="Momentum for SGD/LARS",
     )
     parser.add_argument(
         "--max-cycles",


### PR DESCRIPTION
## Summary
- add `--optimizer` and `--momentum` flags to training arguments
- allow LARS, SGD, or DeepSpeedCPUAdam optimizers in SimCLR
- default weight decay now 1e-4

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874ba564e28833196def9b4646b9aa7