### PR TITLE
Add SDCLR self-damaging contrastive learning method

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ python experiment [... arguments]
 --root_dir
 
 --model_name {ResNet18,ResNet50,ViTSmall,ViTBase}
---ssl_method {SimCLR}
+--ssl_method {SimCLR,SDCLR}
 
 --lr
 --temperature
@@ -59,7 +59,7 @@ Use `--use-temperature-schedule` to enable a cosine schedule for the temperature
 │   │   │                                       # (e.g. resnet-18, resnet-50, ViT)
 │   │   │
 │   │   ├── SSLMethods                          # Self-supervised training methods
-│   │   │                                       # (e.g. SimCLR)
+│   │   │                                       # (e.g. SimCLR, SDCLR)
 │   │   │
 │   │   ├── SSLTypes.py                         # This file defines all SSL methods
 │   │   │                                       # that can be selected in the main script

--- a/experiment/__main__.py
+++ b/experiment/__main__.py
@@ -97,6 +97,7 @@ def init_ssl_type(
         "temperature_min": args.temperature_min,
         "temperature_max": args.temperature_max,
         "t_max": args.t_max,
+        "sdclr_prune_rate": args.get("sdclr_prune_rate", 0.0),
     }
 
     return ssl_type.initialize(**ssl_args)

--- a/experiment/conf/ssl/sdclr.yaml
+++ b/experiment/conf/ssl/sdclr.yaml
@@ -1,0 +1,6 @@
+ssl_method: SDCLR
+lr: 0.5
+temperature: 0.07
+weight_decay: 1e-4
+use_temperature_schedule: false
+sdclr_prune_rate: 0.3

--- a/experiment/models/SSLMethods/SDCLR.py
+++ b/experiment/models/SSLMethods/SDCLR.py
@@ -1,0 +1,152 @@
+import copy
+import math
+import lightning.pytorch as L
+import torch
+import torch.distributed as dist
+from torch import nn
+from torch.optim import SGD, Optimizer
+from torch.optim.lr_scheduler import LambdaLR, LRScheduler
+import torch.nn.functional as F
+
+from experiment.models.SSLMethods.SimCLR import SimCLRProjectionHead
+
+
+class SDCLR(L.LightningModule):
+    def __init__(
+        self,
+        model: nn.Module,
+        lr: float,
+        temperature: float,
+        weight_decay: float,
+        max_epochs: int = 500,
+        hidden_dim: int = 128,
+        use_temperature_schedule: bool = False,
+        sdclr_prune_rate: float = 0.3,
+        *args,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        self.save_hyperparameters(ignore=["model"])
+
+        if torch.cuda.device_count() > 1:
+            model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+
+        assert self.hparams.temperature > 0.0, "The temperature must be a positive float!"
+
+        self.model_dense = model
+        try:
+            if self.model_dense.fc is not None:
+                self.model_dense.fc = SimCLRProjectionHead(
+                    in_dim=self.model_dense.fc.in_features,
+                    hidden_dim=2048,
+                    out_dim=hidden_dim,
+                )
+        except Exception:
+            pass
+
+        self.model_sparse = copy.deepcopy(self.model_dense)
+        for p in self.model_sparse.parameters():
+            p.requires_grad = False
+
+        self._apply_pruning(self.hparams.sdclr_prune_rate)
+
+    # ------------------------------------------------------------------
+    def _compute_threshold(self, model: nn.Module, prune_rate: float) -> float:
+        weights = [p.data.abs().flatten() for p in model.parameters() if p.dim() > 1]
+        if not weights:
+            return 0.0
+        all_weights = torch.cat(weights)
+        k = int(prune_rate * all_weights.numel())
+        if k < 1:
+            return 0.0
+        threshold = torch.kthvalue(all_weights, k).values.item()
+        return threshold
+
+    def _apply_pruning(self, prune_rate: float) -> None:
+        threshold = self._compute_threshold(self.model_dense, prune_rate)
+        for p in self.model_sparse.parameters():
+            if p.dim() > 1:
+                mask = p.data.abs() >= threshold
+                p.data.mul_(mask)
+
+    def on_train_epoch_start(self) -> None:
+        self.model_sparse.load_state_dict(self.model_dense.state_dict())
+        self._apply_pruning(self.hparams.sdclr_prune_rate)
+
+    # ------------------------------------------------------------------
+    def temperature(self) -> float:
+        if not self.hparams.use_temperature_schedule:
+            return self.hparams.temperature
+
+        t_min = self.hparams.temperature_min
+        t_max = self.hparams.temperature_max
+        T = self.hparams.t_max
+        temperature = (t_max - t_min) * (1 + math.cos(math.pi * self.current_epoch / T)) / 2 + t_min
+        return temperature
+
+    def configure_optimizers(self) -> tuple[list[Optimizer], list[LRScheduler]]:
+        optimizer = SGD(
+            filter(lambda p: p.requires_grad, self.parameters()),
+            lr=self.hparams.lr,
+            weight_decay=self.hparams.weight_decay,
+            momentum=0.9,
+        )
+
+        def lr_lambda(epoch):
+            warmup_epochs = 10
+            total_epochs = 800
+            min_lr_ratio = 2 * 1e-6
+            if epoch < warmup_epochs:
+                return (epoch + 1) / warmup_epochs
+            progress = (epoch - warmup_epochs) / (total_epochs - warmup_epochs)
+            return min_lr_ratio + (1 - min_lr_ratio) * 0.5 * (1 + math.cos(math.pi * progress))
+
+        scheduler = LambdaLR(optimizer, lr_lambda=lr_lambda)
+        return [optimizer], [scheduler]
+
+    # ------------------------------------------------------------------
+    def concat_all_gather(self, t: torch.Tensor) -> torch.Tensor:
+        if dist.is_available() and dist.is_initialized():
+            tensors = [torch.zeros_like(t) for _ in range(dist.get_world_size())]
+            dist.all_gather(tensors, t.detach())
+            tensors[dist.get_rank()] = t
+            t = torch.cat(tensors, dim=0)
+        return t
+
+    def info_nce_loss(self, batch, mode: str = "train"):
+        (x_i, x_j), _ = batch
+        z_i = F.normalize(self.model_dense(x_i), dim=-1)
+        z_j = F.normalize(self.model_sparse(x_j), dim=-1)
+
+        z_i = self.concat_all_gather(z_i)
+        z_j = self.concat_all_gather(z_j)
+        feats = torch.cat([z_i, z_j], dim=0)
+
+        cos_sim = F.cosine_similarity(feats[:, None, :], feats[None, :, :], dim=-1)
+        self_mask = torch.eye(cos_sim.shape[0], dtype=torch.bool, device=cos_sim.device)
+        cos_sim.masked_fill_(self_mask, -9e15)
+        pos_mask = self_mask.roll(shifts=feats.shape[0] // 2, dims=0)
+
+        temperature = self.temperature()
+        self.log(f"{mode}_temperature", temperature, sync_dist=True)
+        cos_sim = cos_sim / temperature
+
+        nll = -cos_sim[pos_mask] + torch.logsumexp(cos_sim, dim=-1)
+        loss = nll.mean()
+        self.log(f"{mode}_loss", loss, sync_dist=True)
+
+        comb_sim = torch.cat([cos_sim[pos_mask][:, None], cos_sim.masked_fill(pos_mask, -9e15)], dim=-1)
+        sim_argsort = comb_sim.argsort(dim=-1, descending=True).argmin(dim=-1)
+        self.log(f"{mode}_acc_top1", (sim_argsort == 0).float().mean(), sync_dist=True)
+        self.log(f"{mode}_acc_top5", (sim_argsort < 5).float().mean(), sync_dist=True)
+        self.log(f"{mode}_acc_mean_pos", 1 + sim_argsort.float().mean(), sync_dist=True)
+        return loss
+
+    def training_step(self, batch, batch_idx):
+        return self.info_nce_loss(batch, mode="train")
+
+    def validation_step(self, batch, batch_idx):
+        self.info_nce_loss(batch, mode="val")
+
+    def test_step(self, batch, batch_idx):
+        self.info_nce_loss(batch, mode="test")


### PR DESCRIPTION
## Summary
- add SDCLR lightning module with dense and pruned branches and per-epoch pruning
- register SDCLR as an SSL method with config and flag support
- document SDCLR option in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689db0f40b4c83319684c79a2da0f501