### PR TITLE
Add configurable t-SNE sampling and memory cleanup

### DIFF
--- a/experiment/conf/config.yaml
+++ b/experiment/conf/config.yaml
@@ -62,6 +62,9 @@ checkpoint: null
 checkpoint_list: null
 calc_novelty_score: false
 
+# Visualization
+tsne_max_samples: 10000
+
 # Flags
 
 logger: false


### PR DESCRIPTION
## Summary
- Add `tsne_max_samples` option to limit dataset size when collecting embeddings for t-SNE visualization
- Free GPU memory after t-SNE logging by deleting tensors and emptying CUDA cache
- Expose `tsne_max_samples` in default configuration

## Testing
- `pytest`
- `python -m py_compile experiment/ImbalancedTraining.py`

------
https://chatgpt.com/codex/tasks/task_e_689f3179996c8331a87a8dde59a05df5