### PR TITLE
feat: add optional logging flags

### DIFF
--- a/experiment/conf/config.yaml
+++ b/experiment/conf/config.yaml
@@ -70,6 +70,9 @@ finetune: true
 sample_selection: ood
 remove_diffusion: false
 ood_augmentation: false
+log_tsne: false
+log_class_dist: false
+log_generated_samples: false
 
 # Optional paths
 additional_data_path: null


### PR DESCRIPTION
## Summary
- add config flags to control logging of t-SNE, class distribution, and generated sample images
- respect new flags throughout training by gating visualization and WandB logging

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f3171b18483319ba4a1a7d0d4c20a