### PR TITLE
Use generic ImbalancedDataModule for ImageNet100 benchmarks

### DIFF
--- a/experiment/models/finetuning_benchmarks/ImageNet100FineTune.py
+++ b/experiment/models/finetuning_benchmarks/ImageNet100FineTune.py
@@ -1,6 +1,5 @@
 from torch.utils.data import DataLoader
-from experiment.dataset.ImbalancedImageNetDataModule import ImbalancedImageNetDataModule
-from experiment.dataset.ImageNetVariants import ImageNetVariants
+from experiment.dataset.ImbalancedDataModule import ImbalancedDataModule
 from experiment.dataset.imbalancedness.ImbalanceMethods import ImbalanceMethods
 from experiment.models.finetuning_benchmarks.TransferLearningBenchmark import (
     TransferLearningBenchmark,
@@ -35,8 +34,8 @@ class ImageNet100FineTune(TransferLearningBenchmark):
 
     def get_datasets(self):
         set_seed(self.seed)
-        dm = ImbalancedImageNetDataModule(
-            dataset_variant=ImageNetVariants.ImageNet100,
+        dm = ImbalancedDataModule(
+            dataset_path="clane9/imagenet-100",
             imbalance_method=ImbalanceMethods.NoImbalance,
             transform=self.transform,
         )

--- a/experiment/models/finetuning_benchmarks/ImageNet100KNNClassifier.py
+++ b/experiment/models/finetuning_benchmarks/ImageNet100KNNClassifier.py
@@ -1,6 +1,5 @@
 from torch.utils.data import DataLoader
-from experiment.dataset.ImbalancedImageNetDataModule import ImbalancedImageNetDataModule
-from experiment.dataset.ImageNetVariants import ImageNetVariants
+from experiment.dataset.ImbalancedDataModule import ImbalancedDataModule
 from experiment.dataset.imbalancedness.ImbalanceMethods import ImbalanceMethods
 from experiment.models.finetuning_benchmarks.BaseKNNClassifier import BaseKNNClassifier
 from experiment.utils.set_seed import set_seed
@@ -16,8 +15,8 @@ class ImageNet100KNNClassifier(BaseKNNClassifier):
     def setup(self, stage=None):
         # Recreate the same dataset splits deterministically
         set_seed(self.seed)
-        dm = ImbalancedImageNetDataModule(
-            dataset_variant=ImageNetVariants.ImageNet100,
+        dm = ImbalancedDataModule(
+            dataset_path="clane9/imagenet-100",
             imbalance_method=ImbalanceMethods.NoImbalance,
             transform=self.transform,
         )

--- a/experiment/models/finetuning_benchmarks/ImageNet100LTFineTune.py
+++ b/experiment/models/finetuning_benchmarks/ImageNet100LTFineTune.py
@@ -1,6 +1,5 @@
 from torch.utils.data import DataLoader
-from experiment.dataset.ImbalancedImageNetDataModule import ImbalancedImageNetDataModule
-from experiment.dataset.ImageNetVariants import ImageNetVariants
+from experiment.dataset.ImbalancedDataModule import ImbalancedDataModule
 from experiment.dataset.imbalancedness.ImbalanceMethods import ImbalanceMethods
 from experiment.models.finetuning_benchmarks.TransferLearningBenchmark import (
     TransferLearningBenchmark,
@@ -36,8 +35,8 @@ class ImageNet100LTFineTune(TransferLearningBenchmark):
     def get_datasets(self):
         # Ensure the same long-tailed dataset split as used during training
         set_seed(self.seed)
-        dm = ImbalancedImageNetDataModule(
-            dataset_variant=ImageNetVariants.ImageNet100,
+        dm = ImbalancedDataModule(
+            dataset_path="clane9/imagenet-100",
             imbalance_method=ImbalanceMethods.PowerLawImbalance,
             transform=self.transform,
         )

--- a/experiment/models/finetuning_benchmarks/ImageNet100LTKNNClassifier.py
+++ b/experiment/models/finetuning_benchmarks/ImageNet100LTKNNClassifier.py
@@ -1,6 +1,5 @@
 from torch.utils.data import DataLoader
-from experiment.dataset.ImbalancedImageNetDataModule import ImbalancedImageNetDataModule
-from experiment.dataset.ImageNetVariants import ImageNetVariants
+from experiment.dataset.ImbalancedDataModule import ImbalancedDataModule
 from experiment.dataset.imbalancedness.ImbalanceMethods import ImbalanceMethods
 from experiment.models.finetuning_benchmarks.BaseKNNClassifier import BaseKNNClassifier
 from experiment.utils.set_seed import set_seed
@@ -16,8 +15,8 @@ class ImageNet100LTKNNClassifier(BaseKNNClassifier):
     def setup(self, stage=None):
         # Recreate the exact long-tailed dataset used during training
         set_seed(self.seed)
-        dm = ImbalancedImageNetDataModule(
-            dataset_variant=ImageNetVariants.ImageNet100,
+        dm = ImbalancedDataModule(
+            dataset_path="clane9/imagenet-100",
             imbalance_method=ImbalanceMethods.PowerLawImbalance,
             transform=self.transform,
         )


### PR DESCRIPTION
## Summary
- replace ImbalancedImageNetDataModule usage with generic ImbalancedDataModule
- load ImageNet-100 datasets via HF dataset_path and select imbalance method for LT variant

## Testing
- `python -m py_compile experiment/models/finetuning_benchmarks/ImageNet100FineTune.py experiment/models/finetuning_benchmarks/ImageNet100KNNClassifier.py experiment/models/finetuning_benchmarks/ImageNet100LTFineTune.py experiment/models/finetuning_benchmarks/ImageNet100LTKNNClassifier.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1be1896d08331b0a463d539d151d6