### PR TITLE
feat: make deepspeed optional

### DIFF
--- a/experiment/conf/config.yaml
+++ b/experiment/conf/config.yaml
@@ -75,6 +75,7 @@ ood_augmentation: false
 log_tsne: false
 log_class_dist: false
 log_generated_samples: false
+use_deepspeed: true
 
 # Optional paths
 additional_data_path: null


### PR DESCRIPTION
## Summary
- add `use_deepspeed` flag to config to toggle DeepSpeed usage
- honor flag across training pipeline, defaulting to standard CUDA when disabled
- guard checkpoint conversion when DeepSpeed is off

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b05c7afcd883319aefb89200451213