### PR TITLE
Standardize ABCI job scripts

### DIFF
--- a/jobs-abci/ablations/backbone/resnet50.sh
+++ b/jobs-abci/ablations/backbone/resnet50.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=simclr dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_backbone_resnet50
+mkdir -p job_logs/backbone
 
+python -m experiment model=resnet50 ssl=simclr dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_backbone_resnet50 train_batch_size=512 use_deepspeed=false >& job_logs/backbone/resnet50.out

--- a/jobs-abci/ablations/backbone/vitb.sh
+++ b/jobs-abci/ablations/backbone/vitb.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_backbone_vitb
+mkdir -p job_logs/backbone
 
+python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_backbone_vitb train_batch_size=512 use_deepspeed=false >& job_logs/backbone/vitb.out

--- a/jobs-abci/ablations/backbone/vits.sh
+++ b/jobs-abci/ablations/backbone/vits.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_small ssl=simclr dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_backbone_vits
+mkdir -p job_logs/backbone
 
+python -m experiment model=vit_small ssl=simclr dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_backbone_vits train_batch_size=512 use_deepspeed=false >& job_logs/backbone/vits.out

--- a/jobs-abci/ablations/cycles/cycles_10.sh
+++ b/jobs-abci/ablations/cycles/cycles_10.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=10 n_epochs_per_cycle=10 ood_augmentation=true experiment_name=ablations_cycles_cycles_10
+mkdir -p job_logs/cycles
 
+python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=10 n_epochs_per_cycle=10 ood_augmentation=true experiment_name=ablations_cycles_cycles_10 train_batch_size=512 use_deepspeed=false >& job_logs/cycles/cycles_10.out

--- a/jobs-abci/ablations/cycles/cycles_2.sh
+++ b/jobs-abci/ablations/cycles/cycles_2.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=2 n_epochs_per_cycle=50 ood_augmentation=true experiment_name=ablations_cycles_cycles_2
+mkdir -p job_logs/cycles
 
+python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=2 n_epochs_per_cycle=50 ood_augmentation=true experiment_name=ablations_cycles_cycles_2 train_batch_size=512 use_deepspeed=false >& job_logs/cycles/cycles_2.out

--- a/jobs-abci/ablations/cycles/cycles_20.sh
+++ b/jobs-abci/ablations/cycles/cycles_20.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=20 n_epochs_per_cycle=5 ood_augmentation=true experiment_name=ablations_cycles_cycles_20
+mkdir -p job_logs/cycles
 
+python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=20 n_epochs_per_cycle=5 ood_augmentation=true experiment_name=ablations_cycles_cycles_20 train_batch_size=512 use_deepspeed=false >& job_logs/cycles/cycles_20.out

--- a/jobs-abci/ablations/cycles/cycles_5.sh
+++ b/jobs-abci/ablations/cycles/cycles_5.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_cycles_cycles_5
+mkdir -p job_logs/cycles
 
+python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_cycles_cycles_5 train_batch_size=512 use_deepspeed=false >& job_logs/cycles/cycles_5.out

--- a/jobs-abci/ablations/generation/moco_repopulation.sh
+++ b/jobs-abci/ablations/generation/moco_repopulation.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=moco dataset=imagenet1k_imbalanced remove_diffusion=true max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_generation_moco_repopulation
+mkdir -p job_logs/generation
 
+python -m experiment model=vit_base ssl=moco dataset=imagenet1k_imbalanced remove_diffusion=true max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_generation_moco_repopulation train_batch_size=512 use_deepspeed=false >& job_logs/generation/moco_repopulation.out

--- a/jobs-abci/ablations/generation/moco_stablediffusion.sh
+++ b/jobs-abci/ablations/generation/moco_stablediffusion.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=moco dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_generation_moco_stablediffusion
+mkdir -p job_logs/generation
 
+python -m experiment model=vit_base ssl=moco dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_generation_moco_stablediffusion train_batch_size=512 use_deepspeed=false >& job_logs/generation/moco_stablediffusion.out

--- a/jobs-abci/ablations/generation/simclr_repopulation.sh
+++ b/jobs-abci/ablations/generation/simclr_repopulation.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced remove_diffusion=true max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_generation_simclr_repopulation
+mkdir -p job_logs/generation
 
+python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced remove_diffusion=true max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_generation_simclr_repopulation train_batch_size=512 use_deepspeed=false >& job_logs/generation/simclr_repopulation.out

--- a/jobs-abci/ablations/generation/simclr_stablediffusion.sh
+++ b/jobs-abci/ablations/generation/simclr_stablediffusion.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_generation_simclr_stablediffusion
+mkdir -p job_logs/generation
 
+python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_generation_simclr_stablediffusion train_batch_size=512 use_deepspeed=false >& job_logs/generation/simclr_stablediffusion.out

--- a/jobs-abci/ablations/pretraining/dino.sh
+++ b/jobs-abci/ablations/pretraining/dino.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=dino dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_pretraining_dino
+mkdir -p job_logs/pretraining
 
+python -m experiment model=vit_base ssl=dino dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_pretraining_dino train_batch_size=512 use_deepspeed=false >& job_logs/pretraining/dino.out

--- a/jobs-abci/ablations/pretraining/moco.sh
+++ b/jobs-abci/ablations/pretraining/moco.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=moco dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_pretraining_moco
+mkdir -p job_logs/pretraining
 
+python -m experiment model=vit_base ssl=moco dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_pretraining_moco train_batch_size=512 use_deepspeed=false >& job_logs/pretraining/moco.out

--- a/jobs-abci/ablations/pretraining/simclr.sh
+++ b/jobs-abci/ablations/pretraining/simclr.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_pretraining_simclr
+mkdir -p job_logs/pretraining
 
+python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_pretraining_simclr train_batch_size=512 use_deepspeed=false >& job_logs/pretraining/simclr.out

--- a/jobs-abci/ablations/selection/moco_ood.sh
+++ b/jobs-abci/ablations/selection/moco_ood.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=moco dataset=imagenet1k_imbalanced sample_selection=ood max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_selection_moco_ood
+mkdir -p job_logs/selection
 
+python -m experiment model=vit_base ssl=moco dataset=imagenet1k_imbalanced sample_selection=ood max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_selection_moco_ood train_batch_size=512 use_deepspeed=false >& job_logs/selection/moco_ood.out

--- a/jobs-abci/ablations/selection/moco_uniform.sh
+++ b/jobs-abci/ablations/selection/moco_uniform.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=moco dataset=imagenet1k_imbalanced sample_selection=uniform max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_selection_moco_uniform
+mkdir -p job_logs/selection
 
+python -m experiment model=vit_base ssl=moco dataset=imagenet1k_imbalanced sample_selection=uniform max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_selection_moco_uniform train_batch_size=512 use_deepspeed=false >& job_logs/selection/moco_uniform.out

--- a/jobs-abci/ablations/selection/simclr_ood.sh
+++ b/jobs-abci/ablations/selection/simclr_ood.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced sample_selection=ood max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_selection_simclr_ood
+mkdir -p job_logs/selection
 
+python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced sample_selection=ood max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_selection_simclr_ood train_batch_size=512 use_deepspeed=false >& job_logs/selection/simclr_ood.out

--- a/jobs-abci/ablations/selection/simclr_uniform.sh
+++ b/jobs-abci/ablations/selection/simclr_uniform.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced sample_selection=uniform max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_selection_simclr_uniform
+mkdir -p job_logs/selection
 
+python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced sample_selection=uniform max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=ablations_selection_simclr_uniform train_batch_size=512 use_deepspeed=false >& job_logs/selection/simclr_uniform.out

--- a/jobs-abci/base/vitb_simclr_balanced.sh
+++ b/jobs-abci/base/vitb_simclr_balanced.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_balanced max_cycles=1 n_epochs_per_cycle=100 experiment_name=base_vitb_simclr_balanced
+mkdir -p job_logs/base
 
+python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_balanced max_cycles=1 n_epochs_per_cycle=100 experiment_name=base_vitb_simclr_balanced train_batch_size=512 use_deepspeed=false >& job_logs/base/vitb_simclr_balanced.out

--- a/jobs-abci/base/vitb_simclr_imbalanced.sh
+++ b/jobs-abci/base/vitb_simclr_imbalanced.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=1 n_epochs_per_cycle=100 experiment_name=base_vitb_simclr_imbalanced
+mkdir -p job_logs/base
 
+python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=1 n_epochs_per_cycle=100 experiment_name=base_vitb_simclr_imbalanced train_batch_size=512 use_deepspeed=false >& job_logs/base/vitb_simclr_imbalanced.out

--- a/jobs-abci/base/vitb_simclr_newmethod.sh
+++ b/jobs-abci/base/vitb_simclr_newmethod.sh
@@ -1,6 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=base_vitb_simclr_newmethod
+mkdir -p job_logs/base
 
+python -m experiment model=vit_base ssl=simclr dataset=imagenet1k_imbalanced max_cycles=5 n_epochs_per_cycle=20 ood_augmentation=true experiment_name=base_vitb_simclr_newmethod train_batch_size=512 use_deepspeed=false >& job_logs/base/vitb_simclr_newmethod.out

--- a/jobs-abci/install_environment.sh
+++ b/jobs-abci/install_environment.sh
@@ -1,4 +1,11 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-conda env create -f environment.yml
+mkdir -p job_logs
 
+conda env create -f environment.yml >& job_logs/install_environment.out

--- a/jobs-abci/sota/cifar-10-lt/newmethod.sh
+++ b/jobs-abci/sota/cifar-10-lt/newmethod.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=simclr dataset=cifar10_imbalanced max_cycles=8 n_epochs_per_cycle=100 ood_augmentation=true experiment_name=sota_cifar-10-lt_newmethod
+mkdir -p job_logs/cifar-10-lt
+
+python -m experiment model=resnet50 ssl=simclr dataset=cifar10_imbalanced max_cycles=8 n_epochs_per_cycle=100 ood_augmentation=true experiment_name=sota_cifar-10-lt_newmethod train_batch_size=512 use_deepspeed=false >& job_logs/cifar-10-lt/newmethod.out

--- a/jobs-abci/sota/cifar-10-lt/newmethod_sdclr.sh
+++ b/jobs-abci/sota/cifar-10-lt/newmethod_sdclr.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=sdclr dataset=cifar10_imbalanced max_cycles=8 n_epochs_per_cycle=100 ood_augmentation=true experiment_name=sota_cifar-10-lt_newmethod_sdclr
+mkdir -p job_logs/cifar-10-lt
+
+python -m experiment model=resnet50 ssl=sdclr dataset=cifar10_imbalanced max_cycles=8 n_epochs_per_cycle=100 ood_augmentation=true experiment_name=sota_cifar-10-lt_newmethod_sdclr train_batch_size=512 use_deepspeed=false >& job_logs/cifar-10-lt/newmethod_sdclr.out

--- a/jobs-abci/sota/cifar-10-lt/newmethod_ts.sh
+++ b/jobs-abci/sota/cifar-10-lt/newmethod_ts.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=simclr dataset=cifar10_imbalanced max_cycles=8 n_epochs_per_cycle=100 use_temperature_schedule=true ood_augmentation=true experiment_name=sota_cifar-10-lt_newmethod_ts
+mkdir -p job_logs/cifar-10-lt
+
+python -m experiment model=resnet50 ssl=simclr dataset=cifar10_imbalanced max_cycles=8 n_epochs_per_cycle=100 use_temperature_schedule=true ood_augmentation=true experiment_name=sota_cifar-10-lt_newmethod_ts train_batch_size=512 use_deepspeed=false >& job_logs/cifar-10-lt/newmethod_ts.out

--- a/jobs-abci/sota/cifar-10-lt/sdclr.sh
+++ b/jobs-abci/sota/cifar-10-lt/sdclr.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=sdclr dataset=cifar10_imbalanced max_cycles=1 n_epochs_per_cycle=800 experiment_name=sota_cifar-10-lt_sdclr
+mkdir -p job_logs/cifar-10-lt
+
+python -m experiment model=resnet50 ssl=sdclr dataset=cifar10_imbalanced max_cycles=1 n_epochs_per_cycle=800 experiment_name=sota_cifar-10-lt_sdclr train_batch_size=512 use_deepspeed=false >& job_logs/cifar-10-lt/sdclr.out

--- a/jobs-abci/sota/cifar-10-lt/ts.sh
+++ b/jobs-abci/sota/cifar-10-lt/ts.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=simclr dataset=cifar10_imbalanced max_cycles=1 n_epochs_per_cycle=800 use_temperature_schedule=true experiment_name=sota_cifar-10-lt_ts
+mkdir -p job_logs/cifar-10-lt
+
+python -m experiment model=resnet50 ssl=simclr dataset=cifar10_imbalanced max_cycles=1 n_epochs_per_cycle=800 use_temperature_schedule=true experiment_name=sota_cifar-10-lt_ts train_batch_size=512 use_deepspeed=false >& job_logs/cifar-10-lt/ts.out

--- a/jobs-abci/sota/cifar-100-lt/newmethod.sh
+++ b/jobs-abci/sota/cifar-100-lt/newmethod.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=simclr dataset=cifar100_imbalanced max_cycles=8 n_epochs_per_cycle=100 ood_augmentation=true experiment_name=sota_cifar-100-lt_newmethod
+mkdir -p job_logs/cifar-100-lt
+
+python -m experiment model=resnet50 ssl=simclr dataset=cifar100_imbalanced max_cycles=8 n_epochs_per_cycle=100 ood_augmentation=true experiment_name=sota_cifar-100-lt_newmethod train_batch_size=512 use_deepspeed=false >& job_logs/cifar-100-lt/newmethod.out

--- a/jobs-abci/sota/cifar-100-lt/newmethod_sdclr.sh
+++ b/jobs-abci/sota/cifar-100-lt/newmethod_sdclr.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=sdclr dataset=cifar100_imbalanced max_cycles=8 n_epochs_per_cycle=100 ood_augmentation=true experiment_name=sota_cifar-100-lt_newmethod_sdclr
+mkdir -p job_logs/cifar-100-lt
+
+python -m experiment model=resnet50 ssl=sdclr dataset=cifar100_imbalanced max_cycles=8 n_epochs_per_cycle=100 ood_augmentation=true experiment_name=sota_cifar-100-lt_newmethod_sdclr train_batch_size=512 use_deepspeed=false >& job_logs/cifar-100-lt/newmethod_sdclr.out

--- a/jobs-abci/sota/cifar-100-lt/newmethod_ts.sh
+++ b/jobs-abci/sota/cifar-100-lt/newmethod_ts.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=simclr dataset=cifar100_imbalanced max_cycles=8 n_epochs_per_cycle=100 use_temperature_schedule=true ood_augmentation=true experiment_name=sota_cifar-100-lt_newmethod_ts
+mkdir -p job_logs/cifar-100-lt
+
+python -m experiment model=resnet50 ssl=simclr dataset=cifar100_imbalanced max_cycles=8 n_epochs_per_cycle=100 use_temperature_schedule=true ood_augmentation=true experiment_name=sota_cifar-100-lt_newmethod_ts train_batch_size=512 use_deepspeed=false >& job_logs/cifar-100-lt/newmethod_ts.out

--- a/jobs-abci/sota/cifar-100-lt/sdclr.sh
+++ b/jobs-abci/sota/cifar-100-lt/sdclr.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=sdclr dataset=cifar100_imbalanced max_cycles=1 n_epochs_per_cycle=800 experiment_name=sota_cifar-100-lt_sdclr
+mkdir -p job_logs/cifar-100-lt
+
+python -m experiment model=resnet50 ssl=sdclr dataset=cifar100_imbalanced max_cycles=1 n_epochs_per_cycle=800 experiment_name=sota_cifar-100-lt_sdclr train_batch_size=512 use_deepspeed=false >& job_logs/cifar-100-lt/sdclr.out

--- a/jobs-abci/sota/cifar-100-lt/simclr.sh
+++ b/jobs-abci/sota/cifar-100-lt/simclr.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=simclr dataset=cifar100_imbalanced max_cycles=1 n_epochs_per_cycle=800 experiment_name=sota_cifar-100-lt_simclr
+mkdir -p job_logs/cifar-100-lt
+
+python -m experiment model=resnet50 ssl=simclr dataset=cifar100_imbalanced max_cycles=1 n_epochs_per_cycle=800 experiment_name=sota_cifar-100-lt_simclr train_batch_size=512 use_deepspeed=false >& job_logs/cifar-100-lt/simclr.out

--- a/jobs-abci/sota/cifar-100-lt/ts.sh
+++ b/jobs-abci/sota/cifar-100-lt/ts.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=simclr dataset=cifar100_imbalanced max_cycles=8 n_epochs_per_cycle=100 use_temperature_schedule=true experiment_name=sota_cifar-100-lt_ts
+mkdir -p job_logs/cifar-100-lt
+
+python -m experiment model=resnet50 ssl=simclr dataset=cifar100_imbalanced max_cycles=8 n_epochs_per_cycle=100 use_temperature_schedule=true experiment_name=sota_cifar-100-lt_ts train_batch_size=512 use_deepspeed=false >& job_logs/cifar-100-lt/ts.out

--- a/jobs-abci/sota/imagenet-100-lt/newmethod.sh
+++ b/jobs-abci/sota/imagenet-100-lt/newmethod.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=simclr dataset=imagenet100_imbalanced max_cycles=8 n_epochs_per_cycle=100 ood_augmentation=true experiment_name=sota_imagenet-100-lt_newmethod
+mkdir -p job_logs/imagenet-100-lt
+
+python -m experiment model=resnet50 ssl=simclr dataset=imagenet100_imbalanced max_cycles=8 n_epochs_per_cycle=100 ood_augmentation=true experiment_name=sota_imagenet-100-lt_newmethod train_batch_size=512 use_deepspeed=false >& job_logs/imagenet-100-lt/newmethod.out

--- a/jobs-abci/sota/imagenet-100-lt/newmethod_sdclr.sh
+++ b/jobs-abci/sota/imagenet-100-lt/newmethod_sdclr.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=sdclr dataset=imagenet100_imbalanced max_cycles=8 n_epochs_per_cycle=100 ood_augmentation=true experiment_name=sota_imagenet-100-lt_newmethod_sdclr
+mkdir -p job_logs/imagenet-100-lt
+
+python -m experiment model=resnet50 ssl=sdclr dataset=imagenet100_imbalanced max_cycles=8 n_epochs_per_cycle=100 ood_augmentation=true experiment_name=sota_imagenet-100-lt_newmethod_sdclr train_batch_size=512 use_deepspeed=false >& job_logs/imagenet-100-lt/newmethod_sdclr.out

--- a/jobs-abci/sota/imagenet-100-lt/newmethod_ts.sh
+++ b/jobs-abci/sota/imagenet-100-lt/newmethod_ts.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=simclr dataset=imagenet100_imbalanced max_cycles=8 n_epochs_per_cycle=100 use_temperature_schedule=true ood_augmentation=true experiment_name=sota_imagenet-100-lt_newmethod_ts
+mkdir -p job_logs/imagenet-100-lt
+
+python -m experiment model=resnet50 ssl=simclr dataset=imagenet100_imbalanced max_cycles=8 n_epochs_per_cycle=100 use_temperature_schedule=true ood_augmentation=true experiment_name=sota_imagenet-100-lt_newmethod_ts train_batch_size=512 use_deepspeed=false >& job_logs/imagenet-100-lt/newmethod_ts.out

--- a/jobs-abci/sota/imagenet-100-lt/sdclr.sh
+++ b/jobs-abci/sota/imagenet-100-lt/sdclr.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=sdclr dataset=imagenet100_imbalanced max_cycles=1 n_epochs_per_cycle=800 experiment_name=sota_imagenet-100-lt_sdclr
+mkdir -p job_logs/imagenet-100-lt
+
+python -m experiment model=resnet50 ssl=sdclr dataset=imagenet100_imbalanced max_cycles=1 n_epochs_per_cycle=800 experiment_name=sota_imagenet-100-lt_sdclr train_batch_size=512 use_deepspeed=false >& job_logs/imagenet-100-lt/sdclr.out

--- a/jobs-abci/sota/imagenet-100-lt/simclr.sh
+++ b/jobs-abci/sota/imagenet-100-lt/simclr.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=simclr dataset=imagenet100_imbalanced max_cycles=1 n_epochs_per_cycle=800 experiment_name=sota_imagenet-100-lt_simclr
+mkdir -p job_logs/imagenet-100-lt
+
+python -m experiment model=resnet50 ssl=simclr dataset=imagenet100_imbalanced max_cycles=1 n_epochs_per_cycle=800 experiment_name=sota_imagenet-100-lt_simclr train_batch_size=512 use_deepspeed=false >& job_logs/imagenet-100-lt/simclr.out

--- a/jobs-abci/sota/imagenet-100-lt/ts.sh
+++ b/jobs-abci/sota/imagenet-100-lt/ts.sh
@@ -1,5 +1,13 @@
+#!/bin/sh
+#PBS -q rt_HG
+#PBS -l select=1
+#PBS -l walltime=48:00:00
+#PBS -P gag51492
+
 cd $HOME/FOMO
 
-. jobs/environment.sh
+. jobs-abci/environment.sh
 
-python -m experiment model=resnet50 ssl=simclr dataset=imagenet100_imbalanced max_cycles=8 n_epochs_per_cycle=100 use_temperature_schedule=true experiment_name=sota_imagenet-100-lt_ts
+mkdir -p job_logs/imagenet-100-lt
+
+python -m experiment model=resnet50 ssl=simclr dataset=imagenet100_imbalanced max_cycles=8 n_epochs_per_cycle=100 use_temperature_schedule=true experiment_name=sota_imagenet-100-lt_ts train_batch_size=512 use_deepspeed=false >& job_logs/imagenet-100-lt/ts.out


### PR DESCRIPTION
## Summary
- Add PBS headers, environment sourcing, log handling, and output redirection to all ABCI job scripts
- Include explicit `train_batch_size` and `use_deepspeed` flags for each experiment job
- Adjust installation job to use logging and scheduler directives

## Testing
- `find jobs-abci -name '*.sh' -exec sh -n {} +`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b07a6d29d88331af5c77789051f9fb