### PR TITLE
Log augmentation pairs to WandB

### DIFF
--- a/experiment/conf/config.yaml
+++ b/experiment/conf/config.yaml
@@ -66,7 +66,7 @@ tsne_max_samples: 10000
 
 # Flags
 
-logger: false
+logger: true
 pretrain: true
 finetune: true
 sample_selection: ood
@@ -74,7 +74,9 @@ remove_diffusion: false
 ood_augmentation: false
 log_tsne: false
 log_class_dist: false
-log_generated_samples: false
+log_generated_samples: true
+log_every_n_classes: 1
+max_wandb_augmentation_pairs: 8
 use_deepspeed: true
 
 # Optional paths


### PR DESCRIPTION
## Summary
- enable Weights & Biases logging by default and add configuration for augmentation sampling
- capture and upload a limited set of original/augmented image pairs to W&B alongside existing per-class logging

## Testing
- python -m compileall experiment

------
https://chatgpt.com/codex/tasks/task_e_68e4e3de79e083318592c4a6141a370c