### PR TITLE
Allow overriding dataloader worker count via FOMO_NUM_WORKERS

### DIFF
--- a/experiment/utils/get_num_workers.py
+++ b/experiment/utils/get_num_workers.py
@@ -2,6 +2,14 @@ import os
 
 
 def get_num_workers():
+    override = os.getenv("FOMO_NUM_WORKERS")
+    if override is not None:
+        try:
+            override_value = int(override)
+        except ValueError:
+            override_value = 0
+        return max(0, override_value)
+
     max_num_worker_suggest = None
     if hasattr(os, "sched_getaffinity"):
         try:
@@ -12,6 +20,9 @@ def get_num_workers():
         cpu_count = os.cpu_count()
         if cpu_count is not None:
             max_num_worker_suggest = cpu_count
+
+    if max_num_worker_suggest is None:
+        return 0
 
     num_workers = min(12, int(max_num_worker_suggest * 0.75))
 


### PR DESCRIPTION
### Motivation
- Data loading workers were being killed in some environments due to unreliable CPU detection, causing training to fail. 
- Provide an explicit override to control the number of DataLoader workers when autodetection is not appropriate. 
- Ensure a safe fallback when CPU count detection returns `None` to avoid crashes or exceptions.

### Description
- Read the `FOMO_NUM_WORKERS` environment variable in `experiment/utils/get_num_workers.py` and use it when present. 
- Parse and validate the override as an integer and clamp it with `max(0, override_value)`, treating non-integer values as `0`.
- If CPU detection via `os.sched_getaffinity`/`os.cpu_count` yields `None`, return `0` instead of proceeding with ambiguous values, otherwise preserve the existing `min(12, int(max_num_worker_suggest * 0.75))` logic.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e8d43f6a08331be1d94f991950f62)